### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -11,6 +11,9 @@ on: [pull_request]
 jobs:
   label:
 
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/bryanseah234/rssWebsite2020/security/code-scanning/2](https://github.com/bryanseah234/rssWebsite2020/security/code-scanning/2)

The optimal way to fix this problem is to add a `permissions` block with the least privileges needed. In this workflow, the labeler action needs to read repository contents and needs permission to write labels to pull requests. Add a `permissions` block with `contents: read` and `pull-requests: write`. This can either be placed at the workflow root (applies to all jobs), or at the individual job-level. Since there's only one job, both are equivalent, but following the recommendation, it is clearest to place it at the job level immediately before `runs-on:`.

This means editing `.github/workflows/label.yml`—specifically, adding the following:

```yaml
permissions:
  contents: read
  pull-requests: write
```

just above line 14 (`runs-on: ubuntu-latest`). No other changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


___

### **PR Type**
Other


___

### **Description**
- Add permissions block to GitHub workflow

- Grant minimal required permissions for labeler action

- Fix security code scanning alert


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitHub Workflow"] --> B["Add permissions block"]
  B --> C["contents: read"]
  B --> D["pull-requests: write"]
  C --> E["Security compliance"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>label.yml</strong><dd><code>Add job-level permissions for labeler workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/label.yml

<ul><li>Add <code>permissions</code> block with <code>contents: read</code> and <code>pull-requests: write</code><br> <li> Position permissions block before <code>runs-on</code> in the job definition<br> <li> Follow security best practices for minimal privilege access</ul>


</details>


  </td>
  <td><a href="https://github.com/bryanseah234/rssWebsite2020/pull/20/files#diff-10c0cd6a4f95e78dd4975968a27901c644f6e36a8a75147e3fb86d08e1c1831b">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

